### PR TITLE
Volume client honor set region

### DIFF
--- a/openstackclient/volume/client.py
+++ b/openstackclient/volume/client.py
@@ -54,6 +54,7 @@ def make_client(instance):
         session=instance.session,
         extensions=extensions,
         http_log_debug=http_log_debug,
+        region_name=instance._region_name,
     )
 
     return client


### PR DESCRIPTION
This patch fixes Volume region selection the same as Compute was fixed in https://bugs.launchpad.net/python-openstackclient/+bug/1405416

I do not have access to `identity` or `object` stores, so I can not verify that they are affected, but if they are, the same patch should apply to their `client.py`.

```diff
diff --git a/openstackclient/identity/client.py b/openstackclient/identity/client.py
index daf24e1..d10d046 100644
--- a/openstackclient/identity/client.py
+++ b/openstackclient/identity/client.py
@@ -49,6 +49,7 @@ def make_client(instance):
     LOG.debug('Using auth plugin: %s' % instance._auth_plugin)
     client = identity_client(
         session=instance.session,
+        region_name=instance._region_name,
     )
 
     return client
diff --git a/openstackclient/object/client.py b/openstackclient/object/client.py
index beb7c04..d967cf4 100644
--- a/openstackclient/object/client.py
+++ b/openstackclient/object/client.py
@@ -42,6 +42,7 @@ def make_client(instance):
         session=instance.session,
         service_type='object-store',
         endpoint=endpoint,
+        region_name=instance._region_name,
     )
     return client
```