### PR TITLE
Use OK/ERROR for network agent alive column instead of smileys

### DIFF
--- a/openstackclient/network/v2/network_agent.py
+++ b/openstackclient/network/v2/network_agent.py
@@ -33,7 +33,7 @@ LOG = logging.getLogger(__name__)
 
 class AliveColumn(cliff_columns.FormattableColumn[bool]):
     def human_readable(self) -> str:
-        return ":-)" if self._value else "XXX"
+        return "OK" if self._value else "ERROR"
 
 
 class AdminStateColumn(cliff_columns.FormattableColumn[bool]):


### PR DESCRIPTION
The AliveColumn in network_agent.py currently renders the agent heartbeat status as ":-)"  for alive and "XXX" for not alive. This is inconsistent with the adjacent AdminStateColumn which already uses a clean string representation (UP / DOWN), and generally out of place in a CLI tool used in operational contexts.

This patch changes the representation to OK / ERROR.

Rationale for OK / ERROR:
- UP / DOWN was considered but is already used by AdminStateColumn — using the same strings for two different boolean columns would be ambiguous in output where both columns appear side by side
- ALIVE / DEAD accurately reflects the column name but DEAD feels overly dramatic for what is essentially a heartbeat timeout
- OK / ERROR is short, neutral, and clearly communicates the operational meaning without overlap with existing column values

UP / DOWN or ALIVE / DEAD would also be acceptable alternatives if the community prefers consistency with existing conventions over avoiding ambiguity.